### PR TITLE
增加进入路由处理函数前beforeAll和离开处理函数后的调用afterAll

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ package-lock.json
 .idea/
 .DS_Store
 yarn.lock
+.vscode/

--- a/index.js
+++ b/index.js
@@ -68,7 +68,13 @@ module.exports = (rootPath = 'routes') => {
 
     // does not handle errors
     // pass through to upstream instead
+    if(routeObj['beforeAll']){
+      await routeObj['beforeAll'].call(ctx,method, params)
+    }
     let res = await routeObj[method].call(ctx, params)
+    if(routeObj['afterAll']){
+      await routeObj['afterAll'].call(ctx,method, params)
+    }
     if (res) {
       ctx.body = res
     }

--- a/test/app.js
+++ b/test/app.js
@@ -32,6 +32,7 @@ let test = async () => {
   await assertRoute('POST', '/', 'POST / [index.js]')
   await assertRoute('PUT', '/', 'PUT / [index.js]')
   await assertRoute('DELETE', '/', 'DELETE / [index.js]')
+  await assertRoute('GET','/other','GET /other [other/index.js]')
   await assertRoute('GET', '/nothing', 'Not Found')
   console.log('Passed')
   process.exit(0)

--- a/test/routes/index.js
+++ b/test/routes/index.js
@@ -1,14 +1,21 @@
 exports.route = {
-  async get() {
-    return 'GET / [index.js]'
-  },
-  post() {
-    return 'POST / [index.js]'
-  },
-  put() {
-    return 'PUT / [index.js]'
-  },
-  delete() {
-    return 'DELETE / [index.js]'
-  }
+    beforeAll(method) {
+        this.msg = 'before index.js ' + method;
+    },
+    get() {
+        console.log(this.msg);
+        return 'GET / [index.js]'
+    },
+    post() {
+        console.log(this.msg);
+        return 'POST / [index.js]'
+    },
+    put() {
+        console.log(this.msg);
+        return 'PUT / [index.js]'
+    },
+    delete() {
+        console.log(this.msg);
+        return 'DELETE / [index.js]'
+    }
 }

--- a/test/routes/other/index.js
+++ b/test/routes/other/index.js
@@ -1,5 +1,13 @@
 exports.route = {
+  beforeAll(method){
+    this.msg='before other/index.js '+method;
+  },
+  afterAll(method){
+    this.msg='after other/index.js '+method;
+  },
+
   get() {
+    console.log(this.msg);
     return 'GET /other [other/index.js]'
   }
 }


### PR DESCRIPTION
### 增加
* 进入路由处理函数前的调用
```javascript
beforeAll([method:string,[params:object]]
```
* 离开路由处理函数后的调用 
```javascript
afterAll([method:string,[params:object]]
```

处理函数的参数`method`是`get`,`post`等字符串，即本次请求的请求类型，`params`以及函数内的`this`与路由处理函数一致；
使用方式可以参考测试样例